### PR TITLE
Resolve UFS hang on boot on Lenovo Yoga C630 WOS

### DIFF
--- a/arch/arm64/boot/dts/qcom/sdm850-lenovo-yoga-c630.dts
+++ b/arch/arm64/boot/dts/qcom/sdm850-lenovo-yoga-c630.dts
@@ -569,6 +569,8 @@
 &ufs_mem_phy {
 	status = "okay";
 
+	reset-gpios = <&tlmm 150 GPIO_ACTIVE_LOW>;
+
 	vdda-phy-supply = <&vdda_ufs1_core>;
 	vdda-pll-supply = <&vdda_ufs1_1p2>;
 };


### PR DESCRIPTION
It's seems like all necessary patches is in place so only missing piece is this line in dts

https://github.com/aarch64-laptops/linux/commit/4e5a282f372bc8d1cac8df5a9d5f04427762ee13
https://github.com/aarch64-laptops/linux/commit/06bb541f529cf1870b107f16c24ce577f51ec0ae
https://github.com/aarch64-laptops/linux/commit/bbf8d2b870903bd727f44c5bc9d63282861f4152